### PR TITLE
Add explicit CoreGraphics CGFloat pow use to prevent Swift 5.5

### DIFF
--- a/Source/EasingFunction.swift
+++ b/Source/EasingFunction.swift
@@ -10,6 +10,8 @@
 // <https://github.com/robb/RBBAnimation/blob/a29cafe2fa91e62573cc9967990b0ad2a6b17a76/RBBAnimation/RBBEasingFunction.m>
 
 import Foundation
+import UIKit
+import CoreGraphics
 
 public typealias EasingFunction = (CGFloat) -> (CGFloat)
 
@@ -35,12 +37,12 @@ public let EasingFunctionEaseInCubic: EasingFunction = { t in
 }
 
 public let EasingFunctionEaseOutCubic: EasingFunction = { t in
-    return pow(t - 1, 3) + 1
+    return CoreGraphics.pow(t - 1, 3) + 1
 }
 
 public let EasingFunctionEaseInOutCubic: EasingFunction = { t in
-    if (t < 0.5) { return 4 * pow(t, 3) }
-    return ((t - 1) * pow((2 * t) - 2, 2)) + 1
+    if (t < 0.5) { return 4 * CoreGraphics.pow(t, 3) }
+    return ((t - 1) * CoreGraphics.pow((2 * t) - 2, 2)) + 1
 }
 
 public let EasingFunctionEaseInBounce: EasingFunction = { t in
@@ -49,16 +51,16 @@ public let EasingFunctionEaseInBounce: EasingFunction = { t in
 
 public let EasingFunctionEaseOutBounce: EasingFunction = { t in
     if (t < (4.0 / 11.0)) {
-        return pow((11.0 / 4.0), 2) * pow(t, 2)
+        return CoreGraphics.pow((11.0 / 4.0), 2) * CoreGraphics.pow(t, 2)
     }
     
     if (t < (8.0 / 11.0)) {
-        return (3.0 / 4.0) + (pow((11.0 / 4.0), 2) * pow(t - (6.0 / 11.0), 2))
+        return (3.0 / 4.0) + (CoreGraphics.pow((11.0 / 4.0), 2) * CoreGraphics.pow(t - (6.0 / 11.0), 2))
     }
     
     if (t < (10.0 / 11.0)) {
-        return (15.0 / 16.0) + (pow((11.0 / 4.0), 2) * pow(t - (9.0 / 11.0), 2))
+        return (15.0 / 16.0) + (CoreGraphics.pow((11.0 / 4.0), 2) * CoreGraphics.pow(t - (9.0 / 11.0), 2))
     }
     
-    return (63.0 / 64.0) + (pow((11.0 / 4.0), 2) * pow(t - (21.0 / 22.0), 2))
+    return (63.0 / 64.0) + (CoreGraphics.pow((11.0 / 4.0), 2) * CoreGraphics.pow(t - (21.0 / 22.0), 2))
 }


### PR DESCRIPTION
This PR should be tested with Swift < 5.5 before merging. For now, we can leave it open and just reference this branch on the Podfile from the Xcode 13 test branch